### PR TITLE
Ensure correct canonical path

### DIFF
--- a/docs/config/production/hugo.toml
+++ b/docs/config/production/hugo.toml
@@ -1,2 +1,2 @@
 # Overrides for production environment
-baseurl = "/"
+baseurl = "https://cozycoder.dev/"


### PR DESCRIPTION
It is important to use the full URL here to get the best SEO results.